### PR TITLE
Fixed: Got error when we got multiple site's partners 

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -747,11 +747,17 @@ class MinimalProgramCourseSerializer(MinimalCourseSerializer):
         ).data
 
 
+class _PartnerSlugRelatedField(serializers.SlugRelatedField):
+    """Query partners with specified site_id"""
+    def get_queryset(self):
+        return self.queryset.filter(site_id=self.context["current_site_id"])
+
+
 class MinimalProgramSerializer(serializers.ModelSerializer):
     authoring_organizations = MinimalOrganizationSerializer(read_only=True, many=True)
     courses = serializers.SerializerMethodField()
     type = serializers.SlugRelatedField(slug_field='name', queryset=ProgramType.objects.all(), required=False)
-    partner = serializers.SlugRelatedField(slug_field='name', queryset=Partner.objects.all())
+    partner = _PartnerSlugRelatedField(slug_field='name', queryset=Partner.objects.all())
 
     @classmethod
     def prefetch_queryset(cls, partners, *args, **kwargs):

--- a/course_discovery/apps/api/v1/views/programs.py
+++ b/course_discovery/apps/api/v1/views/programs.py
@@ -68,8 +68,13 @@ class ProgramViewSet(viewsets.ModelViewSet):
 
     def get_serializer_context(self, *args, **kwargs):
         context = super().get_serializer_context(*args, **kwargs)
-        query_params = ['exclude_utm', 'use_full_course_serializer', 'published_course_runs_only',
-                        'marketable_enrollable_course_runs_with_archived']
+
+        query_params = [
+            'exclude_utm', 'use_full_course_serializer', 'published_course_runs_only',
+            'marketable_enrollable_course_runs_with_archived'
+        ]
+        context['current_site_id'] = self.request.site.id
+
         for query_param in query_params:
             context[query_param] = get_query_param(self.request, query_param)
 
@@ -102,7 +107,10 @@ class ProgramViewSet(viewsets.ModelViewSet):
             input_data['marketing_slug'] = input_data.get('title').replace(' ', '+')
 
         program_writer = self.get_serializer_class()  # ProgramSerializer
-        writer = program_writer(data=input_data)
+        writer = program_writer(
+            data=input_data,
+            context={'current_site_id': self.request.site.id}
+        )
         if not writer.is_valid():
             if 'title' in writer.errors:
                 return Response(


### PR DESCRIPTION
# Clarify this issue:
 - We expect one record while we creating a new program.
 - So we need to specify `partner name` + `site id` for making sure the query only return 1 record.
 - But in rest framework. I didn't pass the `site id` into Serializer Obj. for the object member `partner`. Then cause query Serializer.partner with condition `partner name = abc.....` Only.

 # Changes:
 - Passing `site_id` to subquery of Serializer.partner.

 # Testing:
 - Tested in my local. ( Reproduced this issue in local after inserting duplicated core_parter record for 1 site )

Just deploy it on prod server & restart services.