### PR TITLE
CVE Patches (Discovery)

### DIFF
--- a/.travis/run_tests.sh
+++ b/.travis/run_tests.sh
@@ -16,7 +16,7 @@ make requirements
 make requirements.js
 
 pip uninstall cryptography
-pip install cryptography==3.3.2
+pip install cryptography==3.2.1
 pip uninstall Django
 pip install Django==1.11.29
 pip list

--- a/.travis/run_tests.sh
+++ b/.travis/run_tests.sh
@@ -15,6 +15,12 @@ echo '{ "allow_root": true }' > /root/.bowerrc
 make requirements
 make requirements.js
 
+pip uninstall cryptography
+pip install cryptography==3.3.2
+pip uninstall Django
+pip install Django==1.11.29
+pip list
+
 # Ensure documentation can be compiled
 make docs
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 beautifulsoup4==4.5.1
 boto==2.42.0
-cryptography==3.3.2
+cryptography==3.2.1
 django==1.11.29
 django-autocomplete-light==3.1.8
 django-choices==1.4.3

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 beautifulsoup4==4.5.1
 boto==2.42.0
-cryptography==1.7.1
-django==1.11.15
+cryptography==3.3.2
+django==1.11.29
 django-autocomplete-light==3.1.8
 django-choices==1.4.3
 django-compressor==2.1.1


### PR DESCRIPTION
 # Task
 - https://trello.com/c/vYGAy11o

 # CVE Search Tool
 - https://cve.mitre.org/cve/search_cve_list.html

 # Related PRs
 - https://github.com/Learningtribes/platform/pull/1176

 # Patches
 - [cryptography==3.2.1] OR `cryptography==2.9.2`
    - PYPI: https://pypi.org/project/cryptography/3.2.1/
    -  ❌  `CVE-2020-36242` (https://cryptography.io/en/latest/changelog/?highlight=CVE#v3-3-2) , was fixed with version cryptography==3.3.2. ( Ignored,  BECAUSE py3.5 doesn't support it. )
    - `CVE-2020-25659` has been fixed in version 3.2.
    - `CVE-2018-10903` has been fixed in version 2.3.
 - [Django==1.11.29]

