### PR TITLE
Resolved migrations conflicts

### DIFF
--- a/course_discovery/apps/course_metadata/migrations/0090_program_visibility.py
+++ b/course_discovery/apps/course_metadata/migrations/0090_program_visibility.py
@@ -9,7 +9,7 @@ import djchoices.choices
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('course_metadata', '0089_auto_20220111_0906'),
+        ('course_metadata', '0090_auto_20220921_0844'),
     ]
 
     operations = [


### PR DESCRIPTION
# Migration Issue
```
"CommandError: 
Conflicting migrations detected; multiple leaf nodes in the migration graph: 
(0090_program_visibility, 0090_auto_20220921_0844 in course_metadata)."
```

# Tested
 - Migrated on server staging
```
SG > STAGE - 09:25:26 - discovery@ip-172-27-200-71:discovery$python manage.py migrate
Operations to perform:
  Apply all migrations: admin, auth, catalogs, contenttypes, core, course_metadata, django_comments, guardian, ietf_language_tags, publisher, publisher_comments, sessions, sites, social_django, taggit, waffle
Running migrations:
  Applying course_metadata.0089_auto_20220111_0906... OK
  Applying course_metadata.0090_auto_20220921_0844... OK
  Applying course_metadata.0090_program_visibility... OK
```
