### PR TITLE
Freeze library 'greenlet' version ( 1.1.2 )

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -3,6 +3,7 @@
 
 certifi==2016.9.26
 django-ses==0.8.1
+greenlet==1.1.2
 gevent==1.1.2
 gunicorn==19.6.0
 mysqlclient==1.3.9


### PR DESCRIPTION
# Why do we have this PR :  
 - We met a `greenlet` compiling issue while deploying. [DETAIL](https://jenkins-hawthorn.learning-tribes.com.cn:8082/job/setup-program-service/58/consoleFull)
 - Many C++11 compiling error 👇  ( I think that we shouldn't upgrade c++ version , But freeze greenlet version with `greenlet==1.1.2` ):
```
src/greenlet/greenlet_compiler_compat.hpp:66:20: error: ‘noexcept’ does not name a type\n   #define G_NOEXCEPT noexcept\n                      ^\n  src/greenlet/greenlet_greenlet.hpp:167:43: note: in expansion of macro ‘G_NOEXCEPT’\n           void tp_clear(bool own_top_frame) G_NOEXCEPT;\n
...
...
^", "    src/greenlet/greenlet.cpp:187:32: error: expected declaration before end of line", "    In file included from src/greenlet/greenlet_greenlet.hpp:11:0,",
...
```
 - Some keyword like `noexcept` is only useful in C++11.  Because of we always use latest version of `greenlet` (2.0.0)
![image](https://user-images.githubusercontent.com/26813045/199157507-24dd957b-5571-4ca4-bcfc-df29140e915e.png)


# Which version of `greenlet` we could take : 
```
US > BBW - 03:11:45 - ubuntu@ip-172-27-200-242:~$sudo -H -u discovery bash
discovery@learning-tribes:/home/ubuntu$ cd ~
discovery@learning-tribes:~$ source discovery_env
discovery@learning-tribes:~$ cd discovery/
discovery@learning-tribes:~/discovery$ 
discovery@learning-tribes:~/discovery$ 
discovery@learning-tribes:~/discovery$ pip list | grep "greenlet"
DEPRECATION: The default format will switch to columns in the future. You can use --format=(legacy|columns) (or define a format=(legacy|columns) in your pip.conf under the [list] section) to disable this warning.
greenlet (1.1.2)
```

# Tested on Staging
```
SG > STAGE - 03:39:02 - discovery@ip-172-27-200-71:discovery$pip list | grep greenlet
DEPRECATION: The default format will switch to columns in the future. You can use --format=(legacy|columns) (or define a format=(legacy|columns) in your pip.conf under the [list] section) to disable this warning.
greenlet (1.1.2)
You are using pip version 9.0.3, however version 22.3 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
SG > STAGE - 03:39:15 - discovery@ip-172-27-200-71:discovery$pip list | grep gevent
DEPRECATION: The default format will switch to columns in the future. You can use --format=(legacy|columns) (or define a format=(legacy|columns) in your pip.conf under the [list] section) to disable this warning.
gevent (1.1.2)
You are using pip version 9.0.3, however version 22.3 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
SG > STAGE - 03:39:27 - discovery@ip-172-27-200-71:discovery$
SG > STAGE - 03:39:50 - discovery@ip-172-27-200-71:discovery$
SG > STAGE - 03:39:50 - discovery@ip-172-27-200-71:discovery$
SG > STAGE - 03:39:51 - discovery@ip-172-27-200-71:discovery$
SG > STAGE - 03:39:51 - discovery@ip-172-27-200-71:discovery$pip install greenlet==1.1.2
Requirement already satisfied: greenlet==1.1.2 in /edx/app/discovery/venvs/discovery/lib/python3.5/site-packages
You are using pip version 9.0.3, however version 22.3 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
SG > STAGE - 03:40:02 - discovery@ip-172-27-200-71:discovery$pip install gevent==1.1.2
Requirement already satisfied: gevent==1.1.2 in /edx/app/discovery/venvs/discovery/lib/python3.5/site-packages
Requirement already satisfied: greenlet>=0.4.9 in /edx/app/discovery/venvs/discovery/lib/python3.5/site-packages (from gevent==1.1.2)
You are using pip version 9.0.3, however version 22.3 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
SG > STAGE - 03:40:14 - discovery@ip-172-27-200-71:discovery$
SG > STAGE - 03:40:16 - discovery@ip-172-27-200-71:discovery$
SG > STAGE - 03:40:16 - discovery@ip-172-27-200-71:discovery$pip list | grep greenlet
DEPRECATION: The default format will switch to columns in the future. You can use --format=(legacy|columns) (or define a format=(legacy|columns) in your pip.conf under the [list] section) to disable this warning.
greenlet (1.1.2)
You are using pip version 9.0.3, however version 22.3 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
SG > STAGE - 03:40:20 - discovery@ip-172-27-200-71:discovery$pip list | grep gevent
DEPRECATION: The default format will switch to columns in the future. You can use --format=(legacy|columns) (or define a format=(legacy|columns) in your pip.conf under the [list] section) to disable this warning.
gevent (1.1.2)
```
