### PR TITLE
List of added courses is empty on the Learning Paths

### DIFF
--- a/course_discovery/apps/core/utils.py
+++ b/course_discovery/apps/core/utils.py
@@ -103,21 +103,6 @@ def delete_orphans(model):
     model.objects.filter(**kwargs).delete()
 
 
-def delete_expired_courses(removed_course_keys):
-    """Remove courses not existing in LMS."""
-    from traceback import format_exc
-    from course_discovery.apps.course_metadata.models import CourseRun
-
-    # *** The `OneToOneField` was defined with on_delete set to CASCADE, which is the default ***
-    try:
-        logger.info('Deleting expired courses... ( number = {} )'.format(len(removed_course_keys)))
-
-        CourseRun.objects.filter(key__in=removed_course_keys).delete()
-
-    except Exception:
-        logger.error('Got exception while deleting courses : {}', format_exc())
-
-
 class SearchQuerySetWrapper(object):
     """
     Decorates a SearchQuerySet object using a generator for efficient iteration

--- a/course_discovery/apps/core/utils.py
+++ b/course_discovery/apps/core/utils.py
@@ -103,6 +103,21 @@ def delete_orphans(model):
     model.objects.filter(**kwargs).delete()
 
 
+def delete_expired_courses(removed_course_keys):
+    """Remove courses not existing in LMS."""
+    from traceback import format_exc
+    from course_discovery.apps.course_metadata.models import CourseRun
+
+    # *** The `OneToOneField` was defined with on_delete set to CASCADE, which is the default ***
+    try:
+        logger.info('Deleting expired courses... ( number = {} )'.format(len(removed_course_keys)))
+
+        CourseRun.objects.filter(key__in=removed_course_keys).delete()
+
+    except Exception:
+        logger.error('Got exception while deleting courses : {}', format_exc())
+
+
 class SearchQuerySetWrapper(object):
     """
     Decorates a SearchQuerySet object using a generator for efficient iteration

--- a/course_discovery/apps/core/utils.py
+++ b/course_discovery/apps/core/utils.py
@@ -112,6 +112,7 @@ def delete_expired_courses(partner, removed_course_keys):
     try:
         logger.info('Deleting expired courses... ( {} )'.format(','.join(removed_course_keys)))
 
+        # ===> Only delete unused courses for a specified `Partner Code`
         Course.objects.filter(partner=partner, key__in=removed_course_keys).delete()
 
     except Exception:

--- a/course_discovery/apps/core/utils.py
+++ b/course_discovery/apps/core/utils.py
@@ -103,16 +103,16 @@ def delete_orphans(model):
     model.objects.filter(**kwargs).delete()
 
 
-def delete_expired_courses(removed_course_keys):
+def delete_expired_courses(partner, removed_course_keys):
     """Remove courses not existing in LMS."""
     from traceback import format_exc
-    from course_discovery.apps.course_metadata.models import CourseRun
+    from course_discovery.apps.course_metadata.models import Course
 
     # *** The `OneToOneField` was defined with on_delete set to CASCADE, which is the default ***
     try:
-        logger.info('Deleting expired courses... ( number = {} )'.format(len(removed_course_keys)))
+        logger.info('Deleting expired courses... ( {} )'.format(','.join(removed_course_keys)))
 
-        CourseRun.objects.filter(key__in=removed_course_keys).delete()
+        Course.objects.filter(partner=partner, key__in=removed_course_keys).delete()
 
     except Exception:
         logger.error('Got exception while deleting courses : {}', format_exc())

--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -178,6 +178,10 @@ class CoursesApiDataLoader(AbstractDataLoader):
         for body in results:
             course_run_id = body['id']
 
+            if self.is_loading_all_courses:
+                # Loading course key Only...
+                self.loaded_course_keys.add(course_run_id)
+
             try:
                 body = self.clean_strings(body)
                 course_run = self.get_course_run(body)

--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -133,7 +133,7 @@ class CoursesApiDataLoader(AbstractDataLoader):
                 removed_course_keys = local_course_keys - self.loaded_course_keys
 
                 if removed_course_keys:
-                    delete_expired_courses(removed_course_keys)
+                    delete_expired_courses(self.partner, removed_course_keys)
 
             else:
                 logger.error(

--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -76,10 +76,15 @@ class CoursesApiDataLoader(AbstractDataLoader):
         logger.info('Refreshing Courses and CourseRuns from %s...', self.partner.courses_api_url)
 
         initial_page = 1
+        setattr(self, 'course_count', 0)
+        setattr(self, 'loaded_course_keys', set())
         response = self._make_request(initial_page)
         count = response['pagination']['count']
         pages = response['pagination']['num_pages']
         self._process_response(response)
+
+        if not self.course_count:
+            self.course_count = count
 
         pagerange = range(initial_page + 1, pages + 1)
 
@@ -107,6 +112,35 @@ class CoursesApiDataLoader(AbstractDataLoader):
         logger.info('Retrieved %d course runs from %s.', count, self.partner.courses_api_url)
 
         self.delete_orphans()
+        self.delete_expired_courses()
+
+    @property
+    def is_loading_all_courses(self):
+        return not self.modified_x_min_ago
+
+    def delete_expired_courses(self):
+        if self.is_loading_all_courses:
+            logger.info(
+                '*** Maintaining course list...... ( Cached Course number={}, Loaded Course number={} )'.format(
+                    len(self.loaded_course_keys), self.course_count
+                )
+            )
+
+            from course_discovery.apps.core.utils import delete_expired_courses
+
+            if len(self.loaded_course_keys) == self.course_count:
+                local_course_keys = {r['key'] for r in CourseRun.objects.values('key').all()}
+                removed_course_keys = local_course_keys - self.loaded_course_keys
+
+                if removed_course_keys:
+                    delete_expired_courses(removed_course_keys)
+
+            else:
+                logger.error(
+                    '*** Integrity Error of loaded course keys ( Loaded Number({}) != Expect Number({}) )'.format(
+                        len(self.loaded_course_keys), self.course_count
+                    )
+                )
 
     def _load_data(self, page):  # pragma: no cover
         """Make a request for the given page and process the response."""
@@ -138,7 +172,7 @@ class CoursesApiDataLoader(AbstractDataLoader):
         results = response['results']
 
         logger.info(
-            'Retrieved {} {}...'.format(len(results), 'Course runs')
+            'Retrieved {} {}...'.format(len(results), 'Course Keys' if self.is_loading_all_courses else 'Course runs')
         )
 
         for body in results:

--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -76,15 +76,10 @@ class CoursesApiDataLoader(AbstractDataLoader):
         logger.info('Refreshing Courses and CourseRuns from %s...', self.partner.courses_api_url)
 
         initial_page = 1
-        setattr(self, 'course_count', 0)
-        setattr(self, 'loaded_course_keys', set())
         response = self._make_request(initial_page)
         count = response['pagination']['count']
         pages = response['pagination']['num_pages']
         self._process_response(response)
-
-        if not self.course_count:
-            self.course_count = count
 
         pagerange = range(initial_page + 1, pages + 1)
 
@@ -112,35 +107,6 @@ class CoursesApiDataLoader(AbstractDataLoader):
         logger.info('Retrieved %d course runs from %s.', count, self.partner.courses_api_url)
 
         self.delete_orphans()
-        self.delete_expired_courses()
-
-    @property
-    def is_loading_all_courses(self):
-        return not self.modified_x_min_ago
-
-    def delete_expired_courses(self):
-        if self.is_loading_all_courses:
-            logger.info(
-                '*** Maintaining course list...... ( Cached Course number={}, Loaded Course number={} )'.format(
-                    len(self.loaded_course_keys), self.course_count
-                )
-            )
-
-            from course_discovery.apps.core.utils import delete_expired_courses
-
-            if len(self.loaded_course_keys) == self.course_count:
-                local_course_keys = {r['key'] for r in CourseRun.objects.values('key').all()}
-                removed_course_keys = local_course_keys - self.loaded_course_keys
-
-                if removed_course_keys:
-                    delete_expired_courses(removed_course_keys)
-
-            else:
-                logger.error(
-                    '*** Integrity Error of loaded course keys ( Loaded Number({}) != Expect Number({}) )'.format(
-                        len(self.loaded_course_keys), self.course_count
-                    )
-                )
 
     def _load_data(self, page):  # pragma: no cover
         """Make a request for the given page and process the response."""
@@ -172,15 +138,11 @@ class CoursesApiDataLoader(AbstractDataLoader):
         results = response['results']
 
         logger.info(
-            'Retrieved {} {}...'.format(len(results), 'Course Keys' if self.is_loading_all_courses else 'Course runs')
+            'Retrieved {} {}...'.format(len(results), 'Course runs')
         )
 
         for body in results:
             course_run_id = body['id']
-
-            if self.is_loading_all_courses:
-                # Loading course key Only...
-                self.loaded_course_keys.add(course_run_id)
 
             try:
                 body = self.clean_strings(body)


### PR DESCRIPTION
# Task 
 - https://foundever.atlassian.net/browse/TRIB-1082

# How this issue happened:
 - According to the logs, we can see that on EMEA we have two `Partner Code` ( "Myacademysitel" , "GOS" ) in table `core_partner`
```
 - Course run [course-v1:Myacademysitel+wbd121023+12102023] is not publishable.
 - Course run [course-v1:Myacademysitel+wbd171023+231023] is not publishable.
 - Course run [course-v1:Myacademysitel+wbd270923+270923] is not publishable.
 - Course run [course-v1:Myacademysitel+xx+2030] is not publishable.
 - Retrieved 2942 course runs from https://emea-myacademy.learning-tribes.com/api/courses/v1/.
 - *** Maintaining course list...... ( Cached Course number=2942, Loaded Course number=2942 )
 - Deleting expired courses... ( number = 2 )
 - Retrieving access token for partner [GOS]
 - Command is not using threads to write data.
 - Refreshing Courses and CourseRuns from https://emea-myacademy.learning-tribes.com/api/courses/v1/...
 - *** Query all of courses from LMS. page_no=1
 - Retrieved 2 Course Keys...
 - Course run [course-v1:GOS+GOS101+2017_T2] is not publishable.
 - Course run [course-v1:GOS+GOS102+2017_T3] is not publishable.
 - Retrieved 2 course runs from https://emea-myacademy.learning-tribes.com/api/courses/v1/.
 - *** Maintaining course list...... ( Cached Course number=2, Loaded Course number=2 )
 - Deleting expired courses... ( number = 2942 )

```
 - Then we sync and delete unused courses for each `Partner CODE`. It work well until running deleting logic for Partner Code `"GOS"`. As only 2 courses using this partner code. So the script decide to remove all other 2942 courses linked with Partner Code `"Myacademysitel"`.  👉  Because we didn't specify `partner code` for courses deleting SQL.

# Tested this PR in Devstack
 - Tests Passed

# How to fix this issue:
 - Apply this PR first
 - Sync. all courses from LMS to Discovery with script `python manage.py refresh_course_metadata` ( Pls, disable method `delete_expired_courses(...)` first )
 - Remove this line first: https://github.com/Learningtribes/platform/blob/cfed312814d7eb3ac7cd74bd215591b348821a71/lms/djangoapps/program_enrollments/programs/workflows.py#L691 Before running code below.
 - Add code before this line ( https://github.com/Learningtribes/platform/blob/cfed312814d7eb3ac7cd74bd215591b348821a71/lms/djangoapps/program_enrollments/persistance/program_courses.py#L323 ) : 
```
        _course_key = course_in_response['key']
        can_found = True
        while can_found:
            can_found = False
            for idx, c in enumerate(self._courses):
                if c['key'] == _course_key:
                    self._courses.pop(idx)
                    can_found = True
                    break
```
 - Run the following in `python manage.py cms shell` :  
```
#####################################

_username='LT-developer'
current_site_domain = 'emea-myacademy.learning-tribes.com'
from django.contrib.auth.models import User
request_user = User.objects.get(username=_username)

from lms.djangoapps.program_enrollments.programs import (ProgramCourseRegister, ProgramCoursesLoader)
from lms.djangoapps.program_enrollments.persistance.programs import DraftPartialProgram

# Remove this line first: https://github.com/Learningtribes/platform/blob/cfed312814d7eb3ac7cd74bd215591b348821a71/lms/djangoapps/program_enrollments/programs/workflows.py#L691

programs = []
for record in DraftPartialProgram.collection().find():
    _program_uuid = record['uuid']
    _course_ids = [course['key'] for course in record['courses'] for run in course['course_runs']]
    proxy_response = ProgramCoursesLoader(request_user, query_data={}, program_uuid=_program_uuid, current_site_domain=current_site_domain).execute()
    if not len(proxy_response) and len(_course_ids):
        proxy_response = ProgramCourseRegister(request_user, program_uuid=_program_uuid, post_data={'course_ids': _course_ids}, current_site_domain=current_site_domain).execute()
        if len(proxy_response):
            print('DONE')
        else:
            print(proxy_response)
```

 - Rollback this line https://github.com/Learningtribes/platform/blob/cfed312814d7eb3ac7cd74bd215591b348821a71/lms/djangoapps/program_enrollments/programs/workflows.py#L691
 - Rollback added code from file `lms/djangoapps/program_enrollments/persistance/program_courses.py` 
 - Note: 👉  we don’t restart any services in these steps.

# Tested in Devstack
 - Ran `refresh_course_metadata.py` script
```
root@788933e8b50e:/edx/app/discovery/discovery# python manage.py refresh_course_metadata
2024-01-19 05:57:03,553 INFO 674 [course_discovery.apps.course_metadata.management.commands.refresh_course_metadata] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py:67 - COURSE SYNC -- all courses -- START
2024-01-19 05:57:03,554 INFO 674 [course_discovery.apps.course_metadata.management.commands.refresh_course_metadata] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py:74 - COURSE SYNC -- Lock file /tmp/refresh_course_metadata.lock acquired.
2024-01-19 05:57:03,557 INFO 674 [course_discovery.apps.course_metadata.management.commands.refresh_course_metadata] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py:141 - Retrieving access token for partner [edx]
2024-01-19 05:57:03,611 INFO 674 [course_discovery.apps.course_metadata.management.commands.refresh_course_metadata] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py:190 - Command is not using threads to write data.
......
......
......
2024-01-19 05:57:04,524 INFO 674 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:636 - Creating enrollment code Enrollment code for verified seat in edX Demonstration Course with sku A5B6DBE for partner edX
2024-01-19 05:57:04,526 INFO 674 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:346 - Retrieved 1 course seats, 0 course entitlements, and 1 course enrollment codes from http://edx.devstack.ecommerce:18130/api/v2/.
2024-01-19 05:57:04,528 INFO 674 [course_discovery.apps.course_metadata.management.commands.refresh_course_metadata] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py:248 - Data loading complete. Updating API timestamp to 1705643824.5286906.
2024-01-19 05:57:04,529 INFO 674 [course_discovery.apps.course_metadata.management.commands.refresh_course_metadata] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py:82 - COURSE SYNC -- END (duration: 0:00:00.975313)
root@788933e8b50e:/edx/app/discovery/discovery#
root@788933e8b50e:/edx/app/discovery/discovery#
```
 - fixed LearningPath's courses in devstack
![image](https://github.com/Learningtribes/course-discovery/assets/26813045/1bba8723-e303-433c-9097-120b23346ab5)

# Tested on EMEA
 - Accessed LearningPath ( https://studio-emea-myacademy.learning-tribes.com/program_detail/?program_uuid=74bfcdde-dbb8-4824-bef1-295bf3269dd4 ) Detail Page 👇 
![image](https://github.com/Learningtribes/course-discovery/assets/26813045/bfe91da3-84ac-4654-b4ff-7d43a237ab97)
 - Accessed Program About Page
![image](https://github.com/Learningtribes/course-discovery/assets/26813045/bbad0656-2f2d-4b2f-a519-cc7803cfbbff)
 - Checked courses in this LearningPath
```
In [1]: pid ='74bfcdde-dbb8-4824-bef1-295bf3269dd4'
In [3]: from lms.djangoapps.program_enrollments.persistance.programs import DraftPartialProgram
In [4]: draft_program = DraftPartialProgram.query_one({'_id': pid})
In [5]: draft_program_mgr = draft_program.get_program_courses_manager()
In [6]: len(draft_program['courses'])
Out[6]: 6
```

 - Another Learning Paths ( https://studio-emea-myacademy.learning-tribes.com/program_detail/?program_uuid=b7d8bc58-36c0-4f30-b9f8-c1deeca1b821 )
![image](https://github.com/Learningtribes/course-discovery/assets/26813045/d8279833-7f5d-4810-8f24-aab5eaa4b4ee)

 - Draft LearningPath Courses list:
```
In [3]: draft_program = DraftPartialProgram.query_one({'_id': 'b7d8bc58-36c0-4f30-b9f8-c1deeca1b821'})
   ...: draft_program_mgr = draft_program.get_program_courses_manager()
   ...: len(draft_program['courses'])
   ...:
Out[3]: 6
```
