### PR TITLE
optimize logic of getting access_token

### DIFF
--- a/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py
+++ b/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py
@@ -120,6 +120,8 @@ class Command(BaseCommand):
             courses_api_cfg = getattr(settings, 'COURSES_API', None)
             if not courses_api_cfg:
                 raise CommandError('No COURSES_API available!')
+            if Site.objects.count() == 0:
+                raise CommandError('No valid site records in Table django_site!')
             prefix = 'https://' if courses_api_cfg.get('IS_SECURE', True) else 'http://'
 
             logger.info('Retrieving access token...')
@@ -127,21 +129,19 @@ class Command(BaseCommand):
             for site in Site.objects.all():
                 try:
                     access_token_url = '{prefix}{lms_domain}{end_point}/access_token'.format(
-                        prefix=prefix,
-                        lms_domain=site.domain,
+                        prefix=prefix, lms_domain=site.domain,
                         end_point=courses_api_cfg['OIDC_URL_ROOT']
                     )
                     access_token, __ = EdxRestApiClient.get_oauth_access_token(
                         access_token_url,
-                        courses_api_cfg['OIDC_KEY'],
-                        courses_api_cfg['OIDC_SECRET'],
+                        courses_api_cfg['OIDC_KEY'], courses_api_cfg['OIDC_SECRET'],
                         token_type=token_type
                     )
                     courses_api_url = '{prefix}{lms_domain}{end_point}'.format(
-                        prefix=prefix,
-                        lms_domain=site.domain,
+                        prefix=prefix, lms_domain=site.domain,
                         end_point=courses_api_cfg['URL']
                     )
+                    break
                 except Exception as e:
                     logger.warning(
                         'No access token acquired through client_credential flow with url=>{}. Error : {}'.format(


### PR DESCRIPTION
 - Tested in devstack.  @lpfaender 
```
id	domain	name
1	0.0.0.0:18000	edX-1
3	edx.devstack.lms:18000	edX-2


root@788933e8b50e:/edx/app/discovery/discovery# python manage.py refresh_course_metadata
2025-09-22 08:15:31,332 INFO 230 [course_discovery.apps.course_metadata.management.commands.refresh_course_metadata] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py:63 - COURSE SYNC -- all courses -- START
2025-09-22 08:15:31,333 INFO 230 [course_discovery.apps.course_metadata.management.commands.refresh_course_metadata] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py:70 - COURSE SYNC -- Lock file /tmp/refresh_course_metadata.lock acquired.
2025-09-22 08:15:31,338 INFO 230 [course_discovery.apps.course_metadata.management.commands.refresh_course_metadata] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py:127 - Retrieving access token...
2025-09-22 08:15:31,343 WARNING 230 [course_discovery.apps.course_metadata.management.commands.refresh_course_metadata] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py:148 - No access token acquired through client_credential flow with url=>http://0.0.0.0:18000/oauth2/access_token. Error : HTTPConnectionPool(host='0.0.0.0', port=18000): Max retries exceeded with url: /oauth2/access_token (Caused by NewConnectionError('<requests.packages.urllib3.connection.HTTPConnection object at 0x7ffff62be390>: Failed to establish a new connection: [Errno 111] Connection refused',))
2025-09-22 08:15:31,482 INFO 230 [course_discovery.apps.course_metadata.management.commands.refresh_course_metadata] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py:156 - *** Apply course API URL => http://edx.devstack.lms:18000/api/courses/v1/
2025-09-22 08:15:31,498 INFO 230 [course_discovery.apps.course_metadata.management.commands.refresh_course_metadata] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py:190 - Command is not using threads to write data.
2025-09-22 08:15:31,499 INFO 230 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:32 - Refreshing Courses and CourseRuns from /api/courses/v1/...
2025-09-22 08:15:31,499 INFO 230 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:133 - *** Query all of courses from LMS. page_no=1.
2025-09-22 08:15:32,220 INFO 230 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:151 - Retrieved 50 Course Keys...
2025-09-22 08:15:32,226 INFO 230 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:195 - Processed course run with UUID [83c39eec-4395-4c29-a12e-119c2ccad103].
2025-09-22 08:15:32,261 INFO 230 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:223 - Processed course with key [course-v1:edX+ACA_V0001+2023-10-10] | ORG : edX.
2025-09-22 08:15:32,261 INFO 230 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:169 - Processed course with key [course-v1:edX+ACA_V0001+2023-10-10].
2025-09-22 08:15:32,263 INFO 230 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:195 - Processed course run with UUID [09cb0663-ebf6-4f81-83e8-04f57c4a825c].
2025-09-22 08:15:32,266 INFO 230 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:223 - Processed course with key [course-v1:edX+ACBV_0001+2023-10-10] | ORG : edX.
2025-09-22 08:15:32,266 INFO 230 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:169 - Processed course with key [course-v1:edX+ACBV_0001+2023-10-10].
......
......
2025-09-22 08:15:32,436 INFO 230 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:68 - Retrieved 50 course runs from /api/courses/v1/.
2025-09-22 08:15:32,442 INFO 230 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:82 - *** Maintaining course list...... ( Cached Course number=50, Loaded Course number=50 )
2025-09-22 08:15:32,443 INFO 230 [course_discovery.apps.course_metadata.management.commands.refresh_course_metadata] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py:234 - Data loading complete. Updating API timestamp to 1758528932.4429572.
2025-09-22 08:15:32,443 INFO 230 [course_discovery.apps.course_metadata.management.commands.refresh_course_metadata] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py:78 - COURSE SYNC -- END (duration: 0:00:01.111456)
root@788933e8b50e:/edx/app/discovery/discovery#
root@788933e8b50e:/edx/app/discovery/discovery#
```
